### PR TITLE
Fix credential regex characters being escaped.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ TELEGRAM_TOKEN_DEV=HERE
 DATABASE_URL_DEV=postgres://user:password@host:port/database_name
 FOXBIT_API_KEY_DEV=HERE
 FOXBIT_API_SECRET_DEV=HERE
+
+# Test
+DATABASE_URL_TEST=postgres://user:password@host:6969/database_name

--- a/app/db/handshake.py
+++ b/app/db/handshake.py
@@ -13,11 +13,11 @@ def getCredentials():
         database_url = os.getenv('DATABASE_URL_TEST')
         
     cred = {
-        'user': re.search('(?<=postgres://)\w+', database_url).group(0),
-        'password': re.search('postgres://\w+:(\w+)', database_url).group(1),
-        'host': re.search('postgres://\w+:\w+@([^:]*)', database_url).group(1),
-        'port': int(re.search('postgres://\w+:\w+@[^:]*:(\w+)', database_url).group(1)),
-        'database': re.search('postgres://\w+:\w+@[^:]*:\w+/(\w+)', database_url).group(1)
+        'user': re.search(r'(?<=postgres://)\w+', database_url).group(0),
+        'password': re.search(r'postgres://\w+:(\w+)', database_url).group(1),
+        'host': re.search(r'postgres://\w+:\w+@([^:]*)', database_url).group(1),
+        'port': int(re.search(r'postgres://\w+:\w+@[^:]*:(\w+)', database_url).group(1)),
+        'database': re.search(r'postgres://\w+:\w+@[^:]*:\w+/(\w+)', database_url).group(1)
     }
     return cred
 


### PR DESCRIPTION
Closes #56

- Added tests on the .env
- turned credential regex strings, in raw python strings to avoid character escaping

=D