### PR TITLE
[FIX] fserver: fixing exchange_count

### DIFF
--- a/app/foxbit/fserver.py
+++ b/app/foxbit/fserver.py
@@ -144,7 +144,7 @@ class FServer(object):
             if side == 'BUY':
                 trading_setting.exchange_count += 1
             else:
-                trading_setting.exchange_count = 0
+                trading_setting.exchange_count -= 1
             trading_setting.save()
 
             self._telegram_buffer.push({


### PR DESCRIPTION
avoiding reset to 0 when a sale order is done