### PR TITLE
[FEAT] `/open_quotas`: list all active current quotas

### DIFF
--- a/app/foxbit/fserver.py
+++ b/app/foxbit/fserver.py
@@ -216,7 +216,7 @@ class FServer(object):
         })
 
     def _refund_order(self, order: Order):
-        if order.side == 'BUY':
+        if order.side == 'BUY': # TODO: quantity_executed includes fee_paid?
             btc_amount = order.quantity_executed - order.fee_paid
             btc_amount_cost = order.quantity_executed * order.price_avg # taxes included
             brl_amount = order.quantity * order.price

--- a/app/foxbit/mocker.py
+++ b/app/foxbit/mocker.py
@@ -50,7 +50,7 @@ def handle_requests(method, url, headers, params, json):
 
     resource = 'https://api.foxbit.com.br/rest/v3/markets/$market_symbol/candlesticks'
     if route_match(url, method, resource, 'GET'):
-        return execute_public_request(method, url, headers, params, json)
+        return execute_get_candlesticks()
 
     resource = 'https://api.foxbit.com.br/rest/v3/orders'
     if route_match(url, method, resource, 'POST'):
@@ -65,6 +65,28 @@ def handle_requests(method, url, headers, params, json):
 def execute_public_request(method, url, headers, params, json):
     ''' Executing requests that auth is not needed '''
     return requests.request(method, url, headers=headers, params=params, json=json)
+
+def execute_get_candlesticks():
+    ''' Mocking get_candlesticks for user input '''
+
+    price = input("Type the current price: ")
+    data = [
+        [
+            "1692918000000",
+            str(price),
+            str(price),
+            str(price),
+            str(price),
+            "1692918060000",
+            "0.17080431",
+            "21866.35948786",
+            66,
+            "0.12073605",
+            "15466.34096391"
+        ]
+    ]
+
+    return Response(data, 200)
 
 def execute_create_order(data):
     ''' Creating an order - json type '''
@@ -120,15 +142,15 @@ def process_orders():
 
     def apply_taxes(order):
         quantity_executed = float(order.get('quantity_executed', 0.0))        
-        if order['side'] == 'SELL':
+        if order['side'] == 'BUY':
             fee_paid = quantity_executed * 0.005
             order['quantity_executed'] = str(quantity_executed - fee_paid)
         else:
-            fee_paid = float(order['price_avg']) * 0.005
+            fee_paid = (float(order['price_avg']) * float(order['quantity_executed'])) * 0.005
         order['fee_paid'] = str(fee_paid)
 
     def add_trade(order, quantity):
-        perc_diff = random.uniform(0.0, 0.1)
+        perc_diff = random.uniform(0.0, 0.01)
         perc = 1.0 + (perc_diff if order['side'] == 'SELL' else -perc_diff)
         current_price = float(order['price']) * perc
         executed_price = float(order['price_avg'])

--- a/app/session/message.py
+++ b/app/session/message.py
@@ -73,3 +73,15 @@ def trading_info(
   msg += f"Saldo movimentado(BRL):\n{brl_moving} BRL\n"
 
   return msg
+
+def open_quotas(quotas):
+  msg = f"{len(quotas)} Quotas Abertas\n"
+
+  for i in range(len(quotas)):
+    msg += "\n----------------\n"
+    msg += f"Quota #{i + 1}\n\n"
+    msg += f"Preço:       {quotas[i]['price']:.2f} BRL\n"
+    msg += f"Quantidade:  {quotas[i]['amount']:.7f} BTC\n"
+    msg += f"Criada em:   {quotas[i]['created_at'].strftime('%d/%m/%Y')}\n"
+
+  return msg

--- a/app/session/user_session.py
+++ b/app/session/user_session.py
@@ -213,7 +213,7 @@ class UserSession(object):
       if b.base_symbol == 'BRL':
         balance_in_brl = b
       elif b.base_symbol == 'BTC':
-        balance_in_btc = b       
+        balance_in_btc = b
 
     res = await self._foxbit.getCandlesticks(market_symbol='btcbrl', interval='1m', limit=1)
     btc_price = round(float(res[0]['close_price']), 2)
@@ -229,7 +229,7 @@ class UserSession(object):
       price_to_buy = 'Saldo insuficiente'
     else:
       price_to_buy = round((brl_balance / brl_cost) * (trading.percentage_to_buy ** max(trading.exchange_count, 1.0)), 2)
-    
+
     if btc_balance < MINIMUM_BTC_TRADING:
       price_to_sell = 'Saldo insuficiente'
     else:


### PR DESCRIPTION
This PR introduces the `/open_quotas` command, to list all the active current quotas, within 3 informations:
* amount: the total amount of `BTC` for that quota
* price: the cost price to maintain that amount
* created date: the date creation for that quota.

This PR includes also a mocker for `getCandlesticks`. Now, the dev can manipulating the bitcoin price when it is in development mode.

A fix has been applied to `fee_paid` computation on `development` environment, previously the base for `fee_paid` was considering `BTC` for `BRL` and vice-versa.