### PR TITLE
[FIX] fserver: selling price

### DIFF
--- a/app/foxbit/fserver.py
+++ b/app/foxbit/fserver.py
@@ -173,7 +173,7 @@ class FServer(object):
 
             balances: List[Balance] = Balance.where(user_id=[quota.user_id], base_symbol=['BTC'])
 
-            res, code = await self._createOrderLimit(OrderSide.SELL.value, quota.amount, price_for_sell)
+            res, code = await self._createOrderLimit(OrderSide.SELL.value, quota.amount, price)
             if code == 201:
                 partial_price = quota.amount * quota.price
 


### PR DESCRIPTION
prior this commit, the price to sell a quota was the price_sell, defined by the quota price times the selling factor defined for each user. However, now, we are selling the quota by the current price of the market, as it is greater than the price sell.