### PR TITLE
[FIX] fserver: pricing

### DIFF
--- a/app/foxbit/fserver.py
+++ b/app/foxbit/fserver.py
@@ -43,8 +43,8 @@ class FServer(object):
 
                 if candlestick['number_of_trades'] > 5:
                     if highest_price < target_price:
-                        await self._perform_purchase(lowest_price)
-                    await self._perform_sale(highest_price)
+                        await self._perform_purchase(highest_price)
+                    await self._perform_sale(lowest_price)
 
                 await self._process_active_orders()
 


### PR DESCRIPTION
Fixing pricing. Highest_price is used to BUY a currency. Lowest_price is used to SELL a currency.

It avoids order creation that waits in the queue
for a long time.