### PR TITLE
[FEAT] fserver: quota liquidation

### DIFF
--- a/app/foxbit/fserver.py
+++ b/app/foxbit/fserver.py
@@ -176,7 +176,10 @@ class FServer(object):
             price_for_sell = (quota.price * trading_setting.percentage_to_sell)
             liquidation_price = (quota.price * trading_setting.liquidation_rate)
 
-            must_mantain = (price >= liquidation_price and price <= price_for_sell)
+            quota_creation_diff = (datetime.now() - quota.created_at).days
+            QUOTA_SAFE_PERIOD_ALIVE = 30 # 30 days
+
+            must_mantain = ((price >= liquidation_price or quota_creation_diff <= QUOTA_SAFE_PERIOD_ALIVE)  and price <= price_for_sell)
 
             if must_mantain:
                 continue

--- a/tests/test_quotas.py
+++ b/tests/test_quotas.py
@@ -1,4 +1,6 @@
 import pytest
+from datetime import datetime, timedelta
+
 from app.models import Quota
 from app.foxbit import FServer
 
@@ -94,14 +96,26 @@ def test_quotas_creation(db_connection):
 @pytest.mark.asyncio
 async def test_quotas_liquidation(db_connection):
     user = common()
-    create_quota(user.id, 1.0, 100000.0)
+    quota = create_quota(user.id, 1.0, 100000.0)
 
     fserver = FServer()
 
     await fserver._perform_sale(95000.0)
     quotas = Quota.where(quota_state=['ACTIVE'])
-    assert len(quotas) == 1, "The current price is currently in maintain mode"
+    assert len(quotas) == 1, "We must not sell a quota when the market price is above the liquidation price"
 
     await fserver._perform_sale(85000.0)
     quotas = Quota.where(quota_state=['ACTIVE'])
-    assert len(quotas) == 0, "The current price is lower than liquidation rate"
+    assert len(quotas) == 1, "The current price is lower than liquidation rate, but it is a recent created quota"
+
+    # Setting to be an older quota
+    quota.created_at -= timedelta(days=60)
+    quota.save()
+
+    await fserver._perform_sale(95000.0)
+    quotas = Quota.where(quota_state=['ACTIVE'])
+    assert len(quotas) == 1, "The quota is old, but the market price is higher than the liquidation price"
+
+    await fserver._perform_sale(85000.0)
+    quotas = Quota.where(quota_state=['ACTIVE'])
+    assert len(quotas) == 0, "The market price is below the liquidation price AND the quota is old"


### PR DESCRIPTION
Previous this commit, a quota was being sold when the price was higher to its `price` or lower than its `liquidation_price`.

Imagine the follow scenario:

1. The bitcoin starts going down so fast
2. We buy a quota
3. Then, the market's price still going down
4. So, the market's price is so lower than the liquidation price
5. We sell the quota, to avoid higher looses
6. The market's price returns back to a good position after a bad moment.

The above scenario is very common, and we are selling so fast our quotas, it can be not profitable, as we are highly dependent of the market's state. To avoid this, we will just sell quotas that has not been created in the last 30 days.

New quotas selling behavior:

1. The market price is higher then quota's price? Sell it
2. The market price is lower then quota's liquidation price? 2.1 is the quota created in the last 30 days? Don't sell it yet. 2.2 is the quota created before the last 30 days? Sell it.
3. The market price is higher than quota's liquidation AND lower than quota's price? Don't sell it.

Tests has been updated to reflect that new behavior.